### PR TITLE
Testing out warp sync mode

### DIFF
--- a/packages/bitcore-node/src/models/coin.ts
+++ b/packages/bitcore-node/src/models/coin.ts
@@ -31,12 +31,12 @@ class Coin extends BaseModel<ICoin> {
         { partialFilterExpression: { spentHeight: { $lt: 0 } } }
       );
       this.collection.createIndex({ address: 1 });
-      this.collection.createIndex({ mintHeight: 1, chain: 1, network: 1 });
       this.collection.createIndex({ spentHeight: 1, chain: 1, network: 1 });
       this.collection.createIndex({ wallets: 1, spentHeight: 1 }, { sparse: true });
     }
     this.collection.createIndex({ mintTxid: 1 });
     this.collection.createIndex({ spentTxid: 1 }, { sparse: true });
+    this.collection.createIndex({ mintHeight: 1, chain: 1, network: 1 });
   }
 
   getBalance(params: { query: any }) {

--- a/packages/bitcore-node/src/models/coin.ts
+++ b/packages/bitcore-node/src/models/coin.ts
@@ -1,6 +1,7 @@
 import { LoggifyClass } from '../decorators/Loggify';
 import { BaseModel } from './base';
 import { ObjectID } from 'mongodb';
+import Config from '../config';
 
 export type ICoin = {
   network: string;
@@ -24,16 +25,18 @@ class Coin extends BaseModel<ICoin> {
   }
 
   onConnect() {
+    if (!Config.warpSync) {
+      this.collection.createIndex(
+        { mintTxid: 1, mintIndex: 1 },
+        { partialFilterExpression: { spentHeight: { $lt: 0 } } }
+      );
+      this.collection.createIndex({ address: 1 });
+      this.collection.createIndex({ mintHeight: 1, chain: 1, network: 1 });
+      this.collection.createIndex({ spentHeight: 1, chain: 1, network: 1 });
+      this.collection.createIndex({ wallets: 1, spentHeight: 1 }, { sparse: true });
+    }
     this.collection.createIndex({ mintTxid: 1 });
-    this.collection.createIndex(
-      { mintTxid: 1, mintIndex: 1 },
-      { partialFilterExpression: { spentHeight: { $lt: 0 } } }
-    );
-    this.collection.createIndex({ address: 1 });
-    this.collection.createIndex({ mintHeight: 1, chain: 1, network: 1 });
     this.collection.createIndex({ spentTxid: 1 }, { sparse: true });
-    this.collection.createIndex({ spentHeight: 1, chain: 1, network: 1 });
-    this.collection.createIndex({ wallets: 1, spentHeight: 1 }, { sparse: true });
   }
 
   getBalance(params: { query: any }) {

--- a/packages/bitcore-node/src/models/index.ts
+++ b/packages/bitcore-node/src/models/index.ts
@@ -1,8 +1,0 @@
-/*
- *require('../models/coin');
- *require('../models/walletAddress');
- *require('../models/transaction');
- *require('../models/wallet');
- *require('../models/block');
- *
- */

--- a/packages/bitcore-node/src/models/transaction.ts
+++ b/packages/bitcore-node/src/models/transaction.ts
@@ -32,11 +32,13 @@ export class Transaction extends BaseModel<ITransaction> {
   }
 
   onConnect() {
+    if (!config.warpSync) {
+      this.collection.createIndex({ chain: 1, network: 1, blockHeight: 1 });
+      this.collection.createIndex({ chain: 1, network: 1, blockTimeNormalized: 1 });
+      this.collection.createIndex({ wallets: 1 }, { sparse: true });
+      this.collection.createIndex({ blockHash: 1 });
+    }
     this.collection.createIndex({ txid: 1 });
-    this.collection.createIndex({ chain: 1, network: 1, blockHeight: 1 });
-    this.collection.createIndex({ blockHash: 1 });
-    this.collection.createIndex({ chain: 1, network: 1, blockTimeNormalized: 1 });
-    this.collection.createIndex({ wallets: 1 }, { sparse: true });
   }
 
   async batchImport(params: {

--- a/packages/bitcore-node/src/services/p2p/index.ts
+++ b/packages/bitcore-node/src/services/p2p/index.ts
@@ -229,7 +229,7 @@ export class P2pRunner {
         const headers = await this.service.getMissingBlockHashes(locators);
         finalHash = headers[headers.length -1].hash;
         let hashes = headers.map(h => h.hash);
-        this.blockPrefetcher = new Prefetcher(hashes, 50, this.service.getBlock, this.service);
+        this.blockPrefetcher = new Prefetcher(hashes, 10, this.service.getBlock, this.service);
         for (const hash of hashes) {
           const block = await this.getBlock(hash);
           logger.debug('Block received', block.hash);

--- a/packages/bitcore-node/src/services/p2p/index.ts
+++ b/packages/bitcore-node/src/services/p2p/index.ts
@@ -229,7 +229,7 @@ export class P2pRunner {
         const headers = await this.service.getMissingBlockHashes(locators);
         finalHash = headers[headers.length -1].hash;
         let hashes = headers.map(h => h.hash);
-        this.blockPrefetcher = new Prefetcher(hashes, 10, this.service.getBlock, this.service);
+        this.blockPrefetcher = new Prefetcher(hashes, 50, this.service.getBlock, this.service);
         for (const hash of hashes) {
           const block = await this.getBlock(hash);
           logger.debug('Block received', block.hash);

--- a/packages/bitcore-node/src/services/storage.ts
+++ b/packages/bitcore-node/src/services/storage.ts
@@ -5,7 +5,6 @@ import logger from '../logger';
 import config from '../config';
 import { LoggifyClass } from "../decorators/Loggify";
 import { MongoClient, Db } from "mongodb";
-import "../models"
 
 @LoggifyClass
 export class StorageService {

--- a/packages/bitcore-node/src/types/Config.ts
+++ b/packages/bitcore-node/src/types/Config.ts
@@ -1,5 +1,6 @@
 export default interface Config {
   pruneSpentScripts: boolean;
+  warpSync?: boolean;
   maxPoolSize: number;
   port: number;
   dbHost: string;


### PR DESCRIPTION
add warpSync: true to the config, and drop your collections.

Currently averaging 100 ms for addBlock from 0 to 282k

# Before
```
    "BtcP2pService::getBlock": {
        "time": 128569,
        "count": 6481,
        "avg": 19.83783366764388
    },
    "Transaction::addTransactions": {
        "time": 12807,
        "count": 6481,
        "avg": 1.9760839376639407
    },
    "Transaction::batchImport": {
        "time": 41955,
        "count": 6481,
        "avg": 6.4735380342539734
    },
    "Block::addBlock": {
        "time": 73570,
        "count": 6481,
        "avg": 11.351643264928251
    },
```

## After

```
    "BlockSchema::addBlock": {
        "totalTime": 27990186,
        "count": 282884,
        "avg": 98.94580817578937,
        "lastEnded": 1529061362362,
        "totalTimeBetweenRuns": 28339543,
        "avgTimeBetweenRuns": 100.18787473839018
    }
```


After a restart 54% of the way through, averaging ~550 ms per block.
```
    "BlockSchema::addBlock": {
        "totalTime": 264731,
        "count": 514,
        "avg": 515.0408560311284,
        "lastEnded": 1529063327817,
        "totalTimeBetweenRuns": 262205,
        "avgTimeBetweenRuns": 530.7793522267207
    }
```



This mode is not very quick to restart. 
Can take ~10 minutes to restart if you stop it