### PR TITLE
Add route to count coins with specific address

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state.ts
+++ b/packages/bitcore-node/src/providers/chain-state.ts
@@ -45,6 +45,10 @@ export class InternalStateProvider implements CSP.IChainStateService {
     Storage.apiStreamingFind(CoinModel, query, { limit }, stream);
   }
 
+  async countAddressUtxos(params: CSP.CountAddressUtxosParams): Promise<number> {
+    return await CoinModel.collection.count({ params });
+  }
+
   async streamAddressTransactions(params: CSP.StreamAddressUtxosParams) {
     const { limit = 10, stream } = params;
     const query = this.getAddressQuery(params);

--- a/packages/bitcore-node/src/routes/api/address.ts
+++ b/packages/bitcore-node/src/routes/api/address.ts
@@ -44,6 +44,14 @@ router.get('/:address/balance', async function(req, res) {
   }
 });
 
+router.get('/:address/count', async (req, res) => {
+  const { address, chain, network } = req.params;
+  const count = await InternalState.countAddressUtxos({
+    chain, network, address
+  });
+  return res.send({ count });
+});
+
 module.exports = {
   router: router,
   path: '/address'

--- a/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
+++ b/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
@@ -24,6 +24,9 @@ export declare namespace CSP {
   export type GetBalanceForAddressParams = ChainNetwork & {
     address: string;
   };
+  export type CountAddressUtxosParams = ChainNetwork & {
+    address: string;
+  };
   export type GetBalanceForWalletParams = ChainNetwork & {
     walletId: string;
   };


### PR DESCRIPTION
Be sure to test this as bitcore node won't connect to my mongo instance.