### PR TITLE
Add /txs/count route to fetch XRP sequence/nonce

### DIFF
--- a/packages/bitcore-node/src/modules/ripple/api/csp.ts
+++ b/packages/bitcore-node/src/modules/ripple/api/csp.ts
@@ -41,6 +41,16 @@ export class RippleStateProvider extends InternalStateProvider implements CSP.IC
     return RippleStateProvider.clients[network];
   }
 
+  async getAccountNonce(network: string, address: string) {
+    const client = await this.getClient(network);
+    try {
+      const { sequence } = await client.getAccountInfo(address);
+      return sequence;
+    } catch (err) {
+      throw err;
+    }
+  }
+
   async getBalanceForAddress(params: CSP.GetBalanceForAddressParams) {
     const client = await this.getClient(params.network);
     try {
@@ -225,3 +235,5 @@ export class RippleStateProvider extends InternalStateProvider implements CSP.IC
     }
   }
 }
+
+export const XRP = new RippleStateProvider();

--- a/packages/bitcore-node/src/modules/ripple/api/xrp-routes.ts
+++ b/packages/bitcore-node/src/modules/ripple/api/xrp-routes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { XRP } from './csp';
+export const XrpRoutes = Router();
+
+XrpRoutes.get('/api/XRP/:network/address/:address/txs/count', async (req, res) => {
+  let { address, network } = req.params;
+  try {
+    const nonce = await XRP.getAccountNonce(network, address);
+    res.json({ nonce });
+  } catch (err) {
+    res.status(500).send(err);
+  }
+});

--- a/packages/bitcore-node/src/modules/ripple/index.ts
+++ b/packages/bitcore-node/src/modules/ripple/index.ts
@@ -1,11 +1,13 @@
 import { BaseModule } from '..';
 import { RippleStateProvider } from './api/csp';
 import { RippleEventAdapter } from './api/event-adapter';
+import { XrpRoutes } from './api/xrp-routes';
 
 export default class XRPModule extends BaseModule {
   constructor(services: BaseModule['bitcoreServices']) {
     super(services);
     services.CSP.registerService('XRP', new RippleStateProvider());
+    services.Api.app.use(XrpRoutes);
     let adapter = new RippleEventAdapter(services);
 
     services.Event.events.on('start', async () => {


### PR DESCRIPTION
<img width="486" alt="Screen Shot 2019-11-18 at 3 10 52 PM" src="https://user-images.githubusercontent.com/23103037/69088889-a3fbca80-0a15-11ea-8d04-7592bb1ec5a1.png">

Tested using Copay/BWS

Nonce comes back correctly